### PR TITLE
issue#7 タスク登録のバリデーションテスト

### DIFF
--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "タスク管理", type: :feature do
   background do
-    # @user = FactoryBot.create(:user)
+    @user = FactoryBot.create(:user)
     FactoryBot.create(:task)
     FactoryBot.create(:second_task)
     visit tasks_path
@@ -41,5 +41,13 @@ RSpec.feature "タスク管理", type: :feature do
     click_button "ソート"
     tasks = all('.task_item')
     expect(Date.strptime(tasks[0].text)).to be > Date.strptime(tasks[1].text)
+  end
+  scenario "タイトルが空ならバリデーションを通らない" do
+    task = Task.new(title: "", comment: "失敗")
+    expect(task).not_to be_valid
+  end
+  scenario "コメントが空でもバリデーション通る" do
+    task = Task.new(title: "コメントなし", comment: "")
+    expect(task).to be_valid
   end
 end


### PR DESCRIPTION
タスク登録のバリデーションに関して、下記の変更を終えました。

- title は null false (default "新規タスク")

- comment は nullを許可（タスク登録にはタイトルだけで問題ないケースも多いと思われるので）

- タスク登録のバリデーションテスト実装